### PR TITLE
#5 Adding DSL to define properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Newcomers of Gradle Build System very often complain about that in Gradle there 
    * [Sample build script](#sample-build-script)
    * [Defining and executing configurations](#defining-and-executing-configurations)
    * [Providing properties](#providing-properties)
-   * [Validating properties](#validating-properties)
+   * [Defining project properties](#defining-project-properties)
    * [Sample output](#sample-output)
 * [License](#license)
 
@@ -130,37 +130,40 @@ Properties can be provided by (order makes precedence):
   
 4. Mixed approach.
 
-### Validating properties
+### Defining project properties
 
 Configuring of project properties can be enhanced by providing properties definitions which can be used for property value validation, e.g.:
 ```kotlin
 fork {
     properties(mapOf(
-            "enableSmbClient" to {
-                type = CHECKBOX
-                defaultValue = "true"
+            "enableSomething" to {
+                checkbox(defaultValue = true)
             },
-            "aemInstanceAuthorJvmOpts" to {
+            "someJvaOpts" to {
                 optional()
-                defaultValue = "-server -Xmx1024m -XX:MaxPermSize=256M -Djava.awt.headless=true"
-                validator = {
-                    if (!value.startsWith("-")) error("This is not a JVM option!")
+                text(defaultValue = "-server -Xmx1024m -XX:MaxPermSize=256M -Djava.awt.headless=true")
+                validator {
+                    if (value.split(" ").any { !it.startsWith("-") })
+                        error("This is not a JVM option!")
                 }
             },
-            "aemSmbUsername" to {
-                defaultValue = System.getProperty("user.name")
+            "someUserName" to {
+                text(defaultValue = System.getProperty("user.name"))
+            },
+            "someUrl" to {
+                url(defaultValue = "http://localhost:8080")
             },
             "projectGroup" to {
-                defaultValue = "org.neva"
+                text(defaultValue = "org.neva")
             }
     ))
 }
 ```
 
-#### Defining property
+#### Property definition
 Property definition can consists of:
 * type specification: `type = TYPE_NAME`
-  * there are five types available: `TEXT` (default one), `CHECKBOX` (representing boolean), `PASSWORD`, `PATH` & `URL`.
+  * there are five types available: `TEXT` x(default one), `CHECKBOX` (representing boolean), `PASSWORD`, `PATH` & `URL`.
   * there is default convention of type inference using property name (case insensitive):
     * ends with "password" -> `PASSWORD`
     * starts with "enable", "disable" -> `CHECKBOX`

--- a/README.md
+++ b/README.md
@@ -135,28 +135,24 @@ Properties can be provided by (order makes precedence):
 Configuring of project properties can be enhanced by providing properties definitions which can be used for property value validation, e.g.:
 ```kotlin
 fork {
-    properties(mapOf(
-            "enableSomething" to {
+    properties {
+            property("enableSomething") {
                 checkbox(defaultValue = true)
-            },
-            "someJvaOpts" to {
+            }
+            property("someJvaOpts") {
                 optional()
                 text(defaultValue = "-server -Xmx1024m -XX:MaxPermSize=256M -Djava.awt.headless=true")
                 validator {
-                    if (value.split(" ").any { !it.startsWith("-") })
-                        error("This is not a JVM option!")
+                    if (!value.startsWith("-")) error("This is not a JVM option!")
                 }
-            },
-            "someUserName" to {
+            }
+            property("someUserName") {
                 text(defaultValue = System.getProperty("user.name"))
-            },
-            "someUrl" to {
-                url(defaultValue = "http://localhost:8080")
-            },
-            "projectGroup" to {
+            }
+            property("projectGroup") {
                 text(defaultValue = "org.neva")
             }
-    ))
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Newcomers of Gradle Build System very often complain about that in Gradle there 
    * [Sample build script](#sample-build-script)
    * [Defining and executing configurations](#defining-and-executing-configurations)
    * [Providing properties](#providing-properties)
+   * [Validating properties](#validating-properties)
    * [Sample output](#sample-output)
 * [License](#license)
 
@@ -128,6 +129,51 @@ Properties can be provided by (order makes precedence):
     ```
   
 4. Mixed approach.
+
+### Validating properties
+
+Configuring of project properties can be enhanced by providing properties definitions which can be used for property value validation, e.g.:
+```kotlin
+fork {
+    properties(mapOf(
+            "enableSmbClient" to {
+                type = CHECKBOX
+                defaultValue = "true"
+            },
+            "aemInstanceAuthorJvmOpts" to {
+                optional()
+                defaultValue = "-server -Xmx1024m -XX:MaxPermSize=256M -Djava.awt.headless=true"
+                validator = {
+                    if (!value.startsWith("-")) error("This is not a JVM option!")
+                }
+            },
+            "aemSmbUsername" to {
+                defaultValue = System.getProperty("user.name")
+            },
+            "projectGroup" to {
+                defaultValue = "org.neva"
+            }
+    ))
+}
+```
+
+#### Defining property
+Property definition can consists of:
+* type specification: `type = TYPE_NAME`
+  * there are five types available: `TEXT` (default one), `CHECKBOX` (representing boolean), `PASSWORD`, `PATH` & `URL`.
+  * there is default convention of type inference using property name (case insensitive):
+    * ends with "password" -> `PASSWORD`
+    * starts with "enable", "disable" -> `CHECKBOX`
+    * ends with "enabled", "disabled" -> `CHECKBOX`
+    * ends with "url" -> `URL`
+    * ends with "path" -> `PATH`
+    * else -> `TEXT`
+* default value specification: `defaultValue = System.getProperty("user.name")`
+  * if no value would be provided for property `defaultValue` is used
+* declaring property as optional: `optional()`
+  * by default all properties are required
+* specifying custom validator: `validator = {if (!value.startsWith("-")) error("This is not a JVM option!")}`
+  * by default `URL` & `PATH` properties gets basic validation which can be overridden or suppressed: `validator = {}`
 
 ### Sample output
 

--- a/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
@@ -3,19 +3,20 @@ package com.neva.gradle.fork
 import com.neva.gradle.fork.config.Config
 import com.neva.gradle.fork.config.InPlaceConfig
 import com.neva.gradle.fork.config.SourceTargetConfig
-import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import com.neva.gradle.fork.config.properties.PropertyDefinition
+import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import groovy.lang.Closure
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.util.ConfigureUtil
 
 open class ForkExtension(val project: Project) {
 
-  val propertyDefinitions = PropertyDefinitions()
-
   @Input
   val configs = mutableListOf<Config>()
+
+  val propertyDefinitions = PropertyDefinitions()
 
   fun config(name: String): Config {
     return configs.find { it.name == name }
@@ -46,8 +47,14 @@ open class ForkExtension(val project: Project) {
     config(InPlaceConfig(this, name), configurer)
   }
 
-  fun properties(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
-    propertyDefinitions.configure(propertiesConfiguration)
+  fun properties(action: Action<in ForkExtension>) {
+    action.execute(this)
+  }
+
+  fun property(name: String, action: Action<in PropertyDefinition>) {
+    val definition = project.objects.newInstance(PropertyDefinition::class.java, name)
+    action.execute(definition)
+    propertyDefinitions.add(definition)
   }
 
   private fun config(config: Config, configurer: Config.() -> Unit) {

--- a/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
@@ -4,7 +4,7 @@ import com.neva.gradle.fork.config.Config
 import com.neva.gradle.fork.config.InPlaceConfig
 import com.neva.gradle.fork.config.SourceTargetConfig
 import com.neva.gradle.fork.config.properties.PropertiesDefinitions
-import com.neva.gradle.fork.config.properties.PropertyDefinitionDsl
+import com.neva.gradle.fork.config.properties.PropertyDefinition
 import groovy.lang.Closure
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
@@ -46,7 +46,7 @@ open class ForkExtension(val project: Project) {
     config(InPlaceConfig(project, propertiesDefinitions, name), configurer)
   }
 
-  fun properties(propertiesConfiguration: Map<String, PropertyDefinitionDsl.() -> Unit>) {
+  fun properties(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
     propertiesDefinitions.configure(propertiesConfiguration)
   }
 

--- a/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
@@ -12,7 +12,7 @@ import org.gradle.util.ConfigureUtil
 
 open class ForkExtension(val project: Project) {
 
-  private val propertiesDefinitions = PropertyDefinitions()
+  val propertyDefinitions = PropertyDefinitions()
 
   @Input
   val configs = mutableListOf<Config>()
@@ -27,7 +27,7 @@ open class ForkExtension(val project: Project) {
   }
 
   fun config(configurer: Config.() -> Unit) {
-    config(SourceTargetConfig(project, propertiesDefinitions, Config.NAME_DEFAULT), configurer)
+    config(SourceTargetConfig(this, Config.NAME_DEFAULT), configurer)
   }
 
   fun config(name: String, configurer: Closure<*>) {
@@ -35,7 +35,7 @@ open class ForkExtension(val project: Project) {
   }
 
   fun config(name: String, configurer: Config.() -> Unit) {
-    config(SourceTargetConfig(project, propertiesDefinitions, name), configurer)
+    config(SourceTargetConfig(this, name), configurer)
   }
 
   fun inPlaceConfig(name: String, configurer: Closure<*>) {
@@ -43,11 +43,11 @@ open class ForkExtension(val project: Project) {
   }
 
   fun inPlaceConfig(name: String, configurer: Config.() -> Unit) {
-    config(InPlaceConfig(project, propertiesDefinitions, name), configurer)
+    config(InPlaceConfig(this, name), configurer)
   }
 
   fun properties(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
-    propertiesDefinitions.configure(propertiesConfiguration)
+    propertyDefinitions.configure(propertiesConfiguration)
   }
 
   private fun config(config: Config, configurer: Config.() -> Unit) {

--- a/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/ForkExtension.kt
@@ -3,7 +3,7 @@ package com.neva.gradle.fork
 import com.neva.gradle.fork.config.Config
 import com.neva.gradle.fork.config.InPlaceConfig
 import com.neva.gradle.fork.config.SourceTargetConfig
-import com.neva.gradle.fork.config.properties.PropertiesDefinitions
+import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import com.neva.gradle.fork.config.properties.PropertyDefinition
 import groovy.lang.Closure
 import org.gradle.api.Project
@@ -12,7 +12,7 @@ import org.gradle.util.ConfigureUtil
 
 open class ForkExtension(val project: Project) {
 
-  private val propertiesDefinitions = PropertiesDefinitions()
+  private val propertiesDefinitions = PropertyDefinitions()
 
   @Input
   val configs = mutableListOf<Config>()

--- a/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
@@ -1,7 +1,7 @@
 package com.neva.gradle.fork.config
 
 import com.neva.gradle.fork.ForkException
-import com.neva.gradle.fork.config.properties.PropertiesDefinitions
+import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import com.neva.gradle.fork.config.properties.Property
 import com.neva.gradle.fork.config.properties.PropertyPrompt
 import com.neva.gradle.fork.config.rule.*
@@ -17,7 +17,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.*
 
-abstract class Config(val project: Project, private val propertiesDefinitions: PropertiesDefinitions, val name: String) {
+abstract class Config(val project: Project, private val propertyDefinitions: PropertyDefinitions, val name: String) {
 
   private val prompts = mutableMapOf<String, PropertyPrompt>()
 
@@ -26,7 +26,7 @@ abstract class Config(val project: Project, private val propertiesDefinitions: P
   private val rules = mutableListOf<Rule>()
 
   val properties: List<Property>
-    get() = this.prompts.values.map { prompt -> propertiesDefinitions.getProperty(prompt) }
+    get() = this.prompts.values.map { prompt -> propertyDefinitions.getProperty(prompt) }
 
   abstract val sourcePath: String
 
@@ -142,7 +142,7 @@ abstract class Config(val project: Project, private val propertiesDefinitions: P
   }
 
   private fun promptValidate() {
-    val invalidProps = properties.filter { prop -> prop.validate().hasErrors() }.map { it.name }
+    val invalidProps = properties.filter(Property::isInvalid).map { it.name }
     if (invalidProps.isNotEmpty()) {
       throw ForkException("Fork cannot be performed, because of missing properties: $invalidProps."
         + " Specify them via properties file $propsFile or interactive mode.")

--- a/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
@@ -2,8 +2,8 @@ package com.neva.gradle.fork.config
 
 import com.neva.gradle.fork.ForkException
 import com.neva.gradle.fork.config.properties.PropertiesDefinitions
-import com.neva.gradle.fork.config.properties.PropertyDefinition
-import com.neva.gradle.fork.config.properties.PropertyDefinitionDsl
+import com.neva.gradle.fork.config.properties.Property
+import com.neva.gradle.fork.config.properties.PropertyPrompt
 import com.neva.gradle.fork.config.rule.*
 import com.neva.gradle.fork.gui.PropertyDialog
 import com.neva.gradle.fork.template.TemplateEngine

--- a/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/Config.kt
@@ -1,14 +1,13 @@
 package com.neva.gradle.fork.config
 
 import com.neva.gradle.fork.ForkException
-import com.neva.gradle.fork.config.properties.PropertyDefinitions
+import com.neva.gradle.fork.ForkExtension
 import com.neva.gradle.fork.config.properties.Property
 import com.neva.gradle.fork.config.properties.PropertyPrompt
 import com.neva.gradle.fork.config.rule.*
 import com.neva.gradle.fork.gui.PropertyDialog
 import com.neva.gradle.fork.template.TemplateEngine
 import groovy.lang.Closure
-import org.gradle.api.Project
 import org.gradle.api.file.FileTree
 import org.gradle.util.ConfigureUtil
 import org.gradle.util.GFileUtils
@@ -17,7 +16,7 @@ import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.util.*
 
-abstract class Config(val project: Project, private val propertyDefinitions: PropertyDefinitions, val name: String) {
+abstract class Config(private val forkExtension: ForkExtension, val name: String) {
 
   private val prompts = mutableMapOf<String, PropertyPrompt>()
 
@@ -25,8 +24,10 @@ abstract class Config(val project: Project, private val propertyDefinitions: Pro
 
   private val rules = mutableListOf<Rule>()
 
+  val project = forkExtension.project
+
   val properties: List<Property>
-    get() = this.prompts.values.map { prompt -> propertyDefinitions.getProperty(prompt) }
+    get() = this.prompts.values.map { prompt -> forkExtension.propertyDefinitions.getProperty(prompt) }
 
   abstract val sourcePath: String
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
@@ -1,9 +1,9 @@
 package com.neva.gradle.fork.config
 
-import com.neva.gradle.fork.config.properties.PropertiesDefinitions
+import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import org.gradle.api.Project
 
-class InPlaceConfig(project: Project, propertiesDefinitions: PropertiesDefinitions, name: String) : Config(project, propertiesDefinitions, name) {
+class InPlaceConfig(project: Project, propertyDefinitions: PropertyDefinitions, name: String) : Config(project, propertyDefinitions, name) {
 
   override val sourcePath: String by lazy { project.projectDir.absolutePath }
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
@@ -1,8 +1,9 @@
 package com.neva.gradle.fork.config
 
+import com.neva.gradle.fork.config.properties.PropertiesDefinitions
 import org.gradle.api.Project
 
-class InPlaceConfig(project: Project, name: String) : Config(project, name) {
+class InPlaceConfig(project: Project, propertiesDefinitions: PropertiesDefinitions, name: String) : Config(project, propertiesDefinitions, name) {
 
   override val sourcePath: String by lazy { project.projectDir.absolutePath }
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/InPlaceConfig.kt
@@ -1,9 +1,8 @@
 package com.neva.gradle.fork.config
 
-import com.neva.gradle.fork.config.properties.PropertyDefinitions
-import org.gradle.api.Project
+import com.neva.gradle.fork.ForkExtension
 
-class InPlaceConfig(project: Project, propertyDefinitions: PropertyDefinitions, name: String) : Config(project, propertyDefinitions, name) {
+class InPlaceConfig(forkExtension: ForkExtension, name: String) : Config(forkExtension, name) {
 
   override val sourcePath: String by lazy { project.projectDir.absolutePath }
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/Property.kt
@@ -1,0 +1,28 @@
+package com.neva.gradle.fork.config
+
+import com.neva.gradle.fork.config.properties.PropertyDefinition
+import com.neva.gradle.fork.config.properties.ValidatorErrors
+
+class Property(private val definition: PropertyDefinition, private val prompt: PropertyPrompt) {
+
+  val name: String
+    get() = prompt.name
+
+  val valueOrDefault: String
+    get() = definition.defaultValue ?: prompt.valueOrDefault
+
+  val label: String
+    get() = if (required) "${prompt.label}*" else prompt.label
+
+  val type: PropertyPrompt.Type
+    get() = prompt.type
+
+  private val required: Boolean
+    get() = prompt.required || definition.required
+
+  fun validate(propText: String): ValidatorErrors {
+    val result = definition.validate(propText)
+    if (required && propText.isBlank()) result.error("This property is required.")
+    return result
+  }
+}

--- a/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
@@ -1,9 +1,10 @@
 package com.neva.gradle.fork.config
 
+import com.neva.gradle.fork.config.properties.PropertiesDefinitions
 import org.gradle.api.Project
 import java.io.File
 
-class SourceTargetConfig(project: Project, name: String) : Config(project, name) {
+class SourceTargetConfig(project: Project, propertiesDefinitions: PropertiesDefinitions, name: String) : Config(project, propertiesDefinitions, name) {
 
   override val sourcePath: String by lazy(promptProp("sourcePath") {
     project.projectDir.absolutePath

--- a/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
@@ -1,10 +1,9 @@
 package com.neva.gradle.fork.config
 
-import com.neva.gradle.fork.config.properties.PropertyDefinitions
-import org.gradle.api.Project
+import com.neva.gradle.fork.ForkExtension
 import java.io.File
 
-class SourceTargetConfig(project: Project, propertyDefinitions: PropertyDefinitions, name: String) : Config(project, propertyDefinitions, name) {
+class SourceTargetConfig(forkExtension: ForkExtension, name: String) : Config(forkExtension, name) {
 
   override val sourcePath: String by lazy(promptProp("sourcePath") {
     project.projectDir.absolutePath

--- a/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/SourceTargetConfig.kt
@@ -1,10 +1,10 @@
 package com.neva.gradle.fork.config
 
-import com.neva.gradle.fork.config.properties.PropertiesDefinitions
+import com.neva.gradle.fork.config.properties.PropertyDefinitions
 import org.gradle.api.Project
 import java.io.File
 
-class SourceTargetConfig(project: Project, propertiesDefinitions: PropertiesDefinitions, name: String) : Config(project, propertiesDefinitions, name) {
+class SourceTargetConfig(project: Project, propertyDefinitions: PropertyDefinitions, name: String) : Config(project, propertyDefinitions, name) {
 
   override val sourcePath: String by lazy(promptProp("sourcePath") {
     project.projectDir.absolutePath

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -20,10 +20,10 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
     get() = definition.required
 
   fun validate(): Validator {
-    val validator = Validator()
+    val validator = Validator(value)
     if (required || value.isNotBlank()) {
       val validatePropertyValue = definition.validator
-      validator.validatePropertyValue(value)
+      validator.validatePropertyValue()
     }
     if (required && value.isBlank()) validator.error("This property is required.")
     return validator

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -33,7 +33,7 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
     if (shouldBeValidated()) {
       when (definition.validator) {
         null -> applyDefaultValidation(validator)
-        else -> validator.apply(definition.validator ?: {})
+        else -> definition.validator?.execute(validator)
       }
     }
     return validator

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -5,8 +5,11 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
   val name: String
     get() = prompt.name
 
-  val valueOrDefault: String
-    get() = definition.defaultValue ?: prompt.valueOrDefault
+  var value: String
+    set(newValue) {
+      prompt.value = newValue
+    }
+    get() = prompt.valueOrDefault ?: definition.defaultValue
 
   val label: String
     get() = if (required) "${prompt.label}*" else prompt.label
@@ -15,15 +18,15 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
     get() = prompt.type
 
   private val required: Boolean
-    get() = prompt.required || definition.required
+    get() = definition.required
 
-  fun validate(propText: String): Validator {
+  fun validate(): Validator {
     val validator = Validator()
-    if (required || propText.isNotBlank()) {
+    if (required || value.isNotBlank()) {
       val validatePropertyValue = definition.validator
-      validator.validatePropertyValue(propText)
+      validator.validatePropertyValue(value)
     }
-    if (required && propText.isBlank()) validator.error("This property is required.")
+    if (required && value.isBlank()) validator.error("This property is required.")
     return validator
   }
 }

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -17,9 +17,13 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
   private val required: Boolean
     get() = prompt.required || definition.required
 
-  fun validate(propText: String): ValidatorErrors {
-    val result = definition.validate(propText)
-    if (required && propText.isBlank()) result.error("This property is required.")
-    return result
+  fun validate(propText: String): Validator {
+    val validator = Validator()
+    if (required || propText.isNotBlank()) {
+      val validatePropertyValue = definition.validator
+      validator.validatePropertyValue(propText)
+    }
+    if (required && propText.isBlank()) validator.error("This property is required.")
+    return validator
   }
 }

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -1,7 +1,4 @@
-package com.neva.gradle.fork.config
-
-import com.neva.gradle.fork.config.properties.PropertyDefinition
-import com.neva.gradle.fork.config.properties.ValidatorErrors
+package com.neva.gradle.fork.config.properties
 
 class Property(private val definition: PropertyDefinition, private val prompt: PropertyPrompt) {
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/Property.kt
@@ -14,8 +14,7 @@ class Property(private val definition: PropertyDefinition, private val prompt: P
   val label: String
     get() = if (required) "${prompt.label}*" else prompt.label
 
-  val type: PropertyPrompt.Type
-    get() = prompt.type
+  val type: PropertyType = definition.type
 
   private val required: Boolean
     get() = definition.required

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,0 +1,44 @@
+package com.neva.gradle.fork.config.properties
+
+import com.neva.gradle.fork.ForkException
+
+sealed class PropertyDefinitionDsl {
+  var defaultValue: String? = null
+  var validator: ValidatorErrorsDsl.(String) -> Unit = {}
+  abstract fun required()
+}
+
+data class PropertyDefinition(val name: String, var required: Boolean = false) : PropertyDefinitionDsl() {
+  init {
+    if (name.isBlank()) throw ForkException("Name of property definition cannot be blank!")
+  }
+
+  override fun required() {
+    required = true
+  }
+
+  fun validate(value: String): ValidatorErrors {
+    val validatePropertyValue = validator
+    val errors = ValidatorErrors()
+    errors.validatePropertyValue(value)
+    return errors
+  }
+
+  companion object {
+    fun default(name: String) = PropertyDefinition(name)
+  }
+}
+
+sealed class ValidatorErrorsDsl {
+  abstract fun error(message: String)
+}
+
+class ValidatorErrors : ValidatorErrorsDsl() {
+  val errors = mutableListOf<String>()
+
+  override fun error(message: String) {
+    errors.add(message)
+  }
+
+  fun hasErrors() = errors.isNotEmpty()
+}

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,11 +1,9 @@
 package com.neva.gradle.fork.config.properties
 
-import com.neva.gradle.fork.ForkException
-
 class PropertiesDefinitions {
   private val definitions = mutableMapOf<String, PropertyDefinition>()
 
-  fun configure(propertiesConfiguration: Map<String, PropertyDefinitionDsl.() -> Unit>) {
+  fun configure(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
     definitions += propertiesConfiguration.mapValues { PropertyDefinition(it.key).apply(it.value) }
   }
 
@@ -17,41 +15,24 @@ class PropertiesDefinitions {
   }
 }
 
-sealed class PropertyDefinitionDsl {
-  var defaultValue: String? = null
-  var validator: ValidatorErrorsDsl.(String) -> Unit = {}
-  abstract fun required()
-}
-
-class PropertyDefinition(val name: String, var required: Boolean = false) : PropertyDefinitionDsl() {
+class PropertyDefinition(val name: String) {
   init {
-    if (name.isBlank()) throw ForkException("Name of property definition cannot be blank!")
+    if (name.isBlank()) throw PropertyException("Name of property definition cannot be blank!")
   }
 
-  override fun required() {
-    required = true
-  }
+  var required: Boolean = true
+  var defaultValue: String? = null
+  var validator: Validator.(String) -> Unit = {}
 
-  fun validate(value: String): ValidatorErrors {
-    val validatePropertyValue = validator
-    val errors = ValidatorErrors()
-    errors.validatePropertyValue(value)
-    return errors
-  }
-
-  companion object {
-    fun default(name: String) = PropertyDefinition(name)
+  fun optional() {
+    required = false
   }
 }
 
-sealed class ValidatorErrorsDsl {
-  abstract fun error(message: String)
-}
-
-class ValidatorErrors : ValidatorErrorsDsl() {
+class Validator {
   val errors = mutableListOf<String>()
 
-  override fun error(message: String) {
+  fun error(message: String) {
     errors.add(message)
   }
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,10 +1,11 @@
 package com.neva.gradle.fork.config.properties
 
 class PropertyDefinitions {
+
   private val definitions = mutableMapOf<String, PropertyDefinition>()
 
-  fun configure(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
-    definitions += propertiesConfiguration.mapValues { PropertyDefinition(it.key).apply(it.value) }
+  fun configure(configuration: Map<String, PropertyDefinition.() -> Unit>) {
+    definitions += configuration.mapValues { PropertyDefinition(it.key).apply(it.value) }
   }
 
   fun getProperty(prompt: PropertyPrompt): Property {
@@ -20,28 +21,45 @@ class PropertyDefinition(val name: String) {
     if (name.isBlank()) throw PropertyException("Name of property definition cannot be blank!")
   }
 
-  /**
-  Those values are used in DSL to simplify property type specification:
-  `type = CHECKBOX`
-  instead of
-  `type = com.neva.gradle.fork.config.properties.PropertyType.CHECKBOX`
-   */
-  val PASSWORD = PropertyType.PASSWORD
-  val TEXT = PropertyType.TEXT
-  val CHECKBOX = PropertyType.CHECKBOX
-  val PATH = PropertyType.PATH
-  val URL = PropertyType.URL
-
   var required: Boolean = true
   var defaultValue: String = ""
   var validator: (Validator.() -> Unit)? = null
-  var type: PropertyType = calculateDefaultType()
+  var type: PropertyType = determineDefaultType()
 
   fun optional() {
     required = false
   }
 
-  private fun calculateDefaultType() = when {
+  fun validator(validatorLogic: Validator.() -> Unit) {
+    validator = validatorLogic
+  }
+
+  fun checkbox(defaultValue: Boolean = false) {
+    type = PropertyType.CHECKBOX
+    this.defaultValue = defaultValue.toString()
+  }
+
+  fun password(defaultValue: String = "") {
+    type = PropertyType.PASSWORD
+    this.defaultValue = defaultValue
+  }
+
+  fun text(defaultValue: String = "") {
+    type = PropertyType.TEXT
+    this.defaultValue = defaultValue
+  }
+
+  fun path(defaultValue: String = "") {
+    type = PropertyType.PATH
+    this.defaultValue = defaultValue
+  }
+
+  fun url(defaultValue: String = "") {
+    type = PropertyType.URL
+    this.defaultValue = defaultValue
+  }
+
+  private fun determineDefaultType() = when {
     name.endsWith("password", true) -> PropertyType.PASSWORD
     name.startsWith("enable", true) -> PropertyType.CHECKBOX
     name.startsWith("disable", true) -> PropertyType.CHECKBOX

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,6 +1,6 @@
 package com.neva.gradle.fork.config.properties
 
-class PropertiesDefinitions {
+class PropertyDefinitions {
   private val definitions = mutableMapOf<String, PropertyDefinition>()
 
   fun configure(propertiesConfiguration: Map<String, PropertyDefinition.() -> Unit>) {
@@ -20,13 +20,21 @@ class PropertyDefinition(val name: String) {
     if (name.isBlank()) throw PropertyException("Name of property definition cannot be blank!")
   }
 
+  /**
+  Those values are used in DSL to simplify property type specification:
+  `type = CHECKBOX`
+  instead of
+  `type = com.neva.gradle.fork.config.properties.PropertyType.CHECKBOX`
+   */
   val PASSWORD = PropertyType.PASSWORD
   val TEXT = PropertyType.TEXT
   val CHECKBOX = PropertyType.CHECKBOX
+  val PATH = PropertyType.PATH
+  val URL = PropertyType.URL
 
   var required: Boolean = true
   var defaultValue: String = ""
-  var validator: Validator.() -> Unit = {}
+  var validator: (Validator.() -> Unit)? = null
   var type: PropertyType = calculateDefaultType()
 
   fun optional() {
@@ -39,14 +47,18 @@ class PropertyDefinition(val name: String) {
     name.startsWith("disable", true) -> PropertyType.CHECKBOX
     name.endsWith("enabled", true) -> PropertyType.CHECKBOX
     name.endsWith("disabled", true) -> PropertyType.CHECKBOX
+    name.endsWith("path", true) -> PropertyType.PATH
+    name.endsWith("url", true) -> PropertyType.URL
     else -> PropertyType.TEXT
   }
 }
 
 enum class PropertyType {
-  PASSWORD,
   TEXT,
-  CHECKBOX
+  PASSWORD,
+  CHECKBOX,
+  PATH,
+  URL
 }
 
 class Validator(val value: String) {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,8 +1,6 @@
 package com.neva.gradle.fork.config.properties
 
 import com.neva.gradle.fork.ForkException
-import com.neva.gradle.fork.config.Property
-import com.neva.gradle.fork.config.PropertyPrompt
 
 class PropertiesDefinitions {
   private val definitions = mutableMapOf<String, PropertyDefinition>()

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,6 +1,23 @@
 package com.neva.gradle.fork.config.properties
 
 import com.neva.gradle.fork.ForkException
+import com.neva.gradle.fork.config.Property
+import com.neva.gradle.fork.config.PropertyPrompt
+
+class PropertiesDefinitions {
+  private val definitions = mutableMapOf<String, PropertyDefinition>()
+
+  fun configure(propertiesConfiguration: Map<String, PropertyDefinitionDsl.() -> Unit>) {
+    definitions += propertiesConfiguration.mapValues { PropertyDefinition(it.key).apply(it.value) }
+  }
+
+  fun getProperty(prompt: PropertyPrompt): Property {
+    val definition = definitions.getOrElse(prompt.name) {
+      PropertyDefinition(prompt.name)
+    }
+    return Property(definition, prompt)
+  }
+}
 
 sealed class PropertyDefinitionDsl {
   var defaultValue: String? = null
@@ -8,7 +25,7 @@ sealed class PropertyDefinitionDsl {
   abstract fun required()
 }
 
-data class PropertyDefinition(val name: String, var required: Boolean = false) : PropertyDefinitionDsl() {
+class PropertyDefinition(val name: String, var required: Boolean = false) : PropertyDefinitionDsl() {
   init {
     if (name.isBlank()) throw ForkException("Name of property definition cannot be blank!")
   }

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -33,11 +33,13 @@ class PropertyDefinition(val name: String) {
     required = false
   }
 
-  private fun calculateDefaultType(): PropertyType {
-    if (name.endsWith("password", true)) {
-      return PropertyType.PASSWORD
-    }
-    return PropertyType.TEXT
+  private fun calculateDefaultType() = when {
+    name.endsWith("password", true) -> PropertyType.PASSWORD
+    name.startsWith("enable", true) -> PropertyType.CHECKBOX
+    name.startsWith("disable", true) -> PropertyType.CHECKBOX
+    name.endsWith("enabled", true) -> PropertyType.CHECKBOX
+    name.endsWith("disabled", true) -> PropertyType.CHECKBOX
+    else -> PropertyType.TEXT
   }
 }
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -26,7 +26,7 @@ class PropertyDefinition(val name: String) {
 
   var required: Boolean = true
   var defaultValue: String = ""
-  var validator: Validator.(String) -> Unit = {}
+  var validator: Validator.() -> Unit = {}
   var type: PropertyType = calculateDefaultType()
 
   fun optional() {
@@ -47,7 +47,7 @@ enum class PropertyType {
   CHECKBOX
 }
 
-class Validator {
+class Validator(val value: String) {
   val errors = mutableListOf<String>()
 
   fun error(message: String) {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -1,11 +1,14 @@
 package com.neva.gradle.fork.config.properties
 
+import org.gradle.api.Action
+import javax.inject.Inject
+
 class PropertyDefinitions {
 
   private val definitions = mutableMapOf<String, PropertyDefinition>()
 
-  fun configure(configuration: Map<String, PropertyDefinition.() -> Unit>) {
-    definitions += configuration.mapValues { PropertyDefinition(it.key).apply(it.value) }
+  fun add(propertyDefinition: PropertyDefinition) {
+    definitions += propertyDefinition.name to propertyDefinition
   }
 
   fun getProperty(prompt: PropertyPrompt): Property {
@@ -16,22 +19,23 @@ class PropertyDefinitions {
   }
 }
 
-class PropertyDefinition(val name: String) {
+open class PropertyDefinition @Inject constructor(val name: String) {
+
   init {
     if (name.isBlank()) throw PropertyException("Name of property definition cannot be blank!")
   }
 
   var required: Boolean = true
   var defaultValue: String = ""
-  var validator: (Validator.() -> Unit)? = null
+  var validator: (Action<in Validator>)? = null
   var type: PropertyType = determineDefaultType()
 
   fun optional() {
     required = false
   }
 
-  fun validator(validatorLogic: Validator.() -> Unit) {
-    validator = validatorLogic
+  fun validator(validateAction: Action<in Validator>) {
+    validator = validateAction
   }
 
   fun checkbox(defaultValue: Boolean = false) {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -20,13 +20,31 @@ class PropertyDefinition(val name: String) {
     if (name.isBlank()) throw PropertyException("Name of property definition cannot be blank!")
   }
 
+  val PASSWORD = PropertyType.PASSWORD
+  val TEXT = PropertyType.TEXT
+  val CHECKBOX = PropertyType.CHECKBOX
+
   var required: Boolean = true
   var defaultValue: String = ""
   var validator: Validator.(String) -> Unit = {}
+  var type: PropertyType = calculateDefaultType()
 
   fun optional() {
     required = false
   }
+
+  private fun calculateDefaultType(): PropertyType {
+    if (name.endsWith("password", true)) {
+      return PropertyType.PASSWORD
+    }
+    return PropertyType.TEXT
+  }
+}
+
+enum class PropertyType {
+  PASSWORD,
+  TEXT,
+  CHECKBOX
 }
 
 class Validator {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyDefinition.kt
@@ -21,7 +21,7 @@ class PropertyDefinition(val name: String) {
   }
 
   var required: Boolean = true
-  var defaultValue: String? = null
+  var defaultValue: String = ""
   var validator: Validator.(String) -> Unit = {}
 
   fun optional() {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyException.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyException.kt
@@ -1,4 +1,4 @@
-package com.neva.gradle.fork.config
+package com.neva.gradle.fork.config.properties
 
 import com.neva.gradle.fork.ForkException
 

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
@@ -1,6 +1,6 @@
 package com.neva.gradle.fork.config.properties
 
-class PropertyPrompt(val name: String, private val defaultProvider: () -> String?) {
+class PropertyPrompt(val name: String, private val defaultProvider: () -> String? = { null }) {
 
   enum class Type(val check: (PropertyPrompt) -> Boolean) {
     PASSWORD({ it.name.endsWith("password", true) }),
@@ -15,16 +15,10 @@ class PropertyPrompt(val name: String, private val defaultProvider: () -> String
 
   var value: String? = null
 
-  val valueOrDefault: String
-    get() = value ?: defaultValue ?: ""
+  val valueOrDefault: String?
+    get() = value ?: defaultValue
 
-  val required: Boolean
-    get() = defaultValue == null
-
-  val valid: Boolean
-    get() = !required || valueOrDefault.isNotEmpty()
-
-  val defaultValue: String? by lazy {
+  private val defaultValue: String? by lazy {
     try {
       defaultProvider()
     } catch (e: PropertyException) {

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
@@ -2,17 +2,6 @@ package com.neva.gradle.fork.config.properties
 
 class PropertyPrompt(val name: String, private val defaultProvider: () -> String? = { null }) {
 
-  enum class Type(val check: (PropertyPrompt) -> Boolean) {
-    PASSWORD({ it.name.endsWith("password", true) }),
-    TEXT({ true });
-
-    companion object {
-      fun of(prompt: PropertyPrompt): Type {
-        return values().first { it.check(prompt) }
-      }
-    }
-  }
-
   var value: String? = null
 
   val valueOrDefault: String?
@@ -25,9 +14,6 @@ class PropertyPrompt(val name: String, private val defaultProvider: () -> String
       null
     }
   }
-
-  val type: Type
-    get() = Type.of(this)
 
   val label: String
     get() = name

--- a/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/config/properties/PropertyPrompt.kt
@@ -1,4 +1,4 @@
-package com.neva.gradle.fork.config
+package com.neva.gradle.fork.config.properties
 
 class PropertyPrompt(val name: String, private val defaultProvider: () -> String?) {
 

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
@@ -113,7 +113,6 @@ class PropertyDialog(private val config: Config) {
     closeButton.isEnabled = valid
     pathButton.isEnabled = isFieldSelected
     dialog.isVisible = true
-    dialog.pack()
   }
 
   private val valid: Boolean

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
@@ -52,8 +52,8 @@ class PropertyDialog(private val config: Config) {
       dialog.add(label, "align label")
 
       val field = when (property.type) {
-        PropertyPrompt.Type.PASSWORD -> JPasswordField(property.valueOrDefault)
-        else -> JTextField(property.valueOrDefault)
+        PropertyPrompt.Type.PASSWORD -> JPasswordField(property.value)
+        else -> JTextField(property.value)
       }
       field.document.addDocumentListener(object : DocumentListener() {
         override fun change(e: DocumentEvent) {
@@ -71,7 +71,7 @@ class PropertyDialog(private val config: Config) {
       val validationMessage = JLabel()
       dialog.add(validationMessage, "skip, wrap")
 
-      PropertyDialogField(property = property, dialog = dialog, validationMessageLabel = validationMessage, propField = field)
+      PropertyDialogField(property, field, validationMessage)
     }
 
   private var closeButton = JButton().apply {
@@ -100,13 +100,14 @@ class PropertyDialog(private val config: Config) {
   }
 
   val props: Map<String, String>
-    get() = fields.fold(mutableMapOf()) { r, e -> r[e.name] = e.textValue;r }
+    get() = fields.fold(mutableMapOf()) { r, e -> r[e.name] = e.value;r }
 
   fun update() {
     val isFieldSelected = fieldFocused != null
     closeButton.isEnabled = valid
     pathButton.isEnabled = isFieldSelected
     dialog.isVisible = true
+    dialog.pack()
   }
 
   private val valid: Boolean

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
@@ -1,7 +1,7 @@
 package com.neva.gradle.fork.gui
 
 import com.neva.gradle.fork.config.Config
-import com.neva.gradle.fork.config.PropertyPrompt
+import com.neva.gradle.fork.config.properties.PropertyPrompt
 import net.miginfocom.swing.MigLayout
 import java.awt.Toolkit
 import java.awt.event.FocusEvent

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialog.kt
@@ -1,7 +1,7 @@
 package com.neva.gradle.fork.gui
 
 import com.neva.gradle.fork.config.Config
-import com.neva.gradle.fork.config.properties.PropertyPrompt
+import com.neva.gradle.fork.config.properties.PropertyType
 import net.miginfocom.swing.MigLayout
 import java.awt.Toolkit
 import java.awt.event.FocusEvent
@@ -9,6 +9,7 @@ import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.*
 import javax.swing.event.DocumentEvent
+
 
 class PropertyDialog(private val config: Config) {
 
@@ -51,27 +52,32 @@ class PropertyDialog(private val config: Config) {
       val label = JLabel(property.label)
       dialog.add(label, "align label")
 
-      val field = when (property.type) {
-        PropertyPrompt.Type.PASSWORD -> JPasswordField(property.value)
+      val field: JComponent = when (property.type) {
+        PropertyType.PASSWORD -> JPasswordField(property.value)
+        PropertyType.CHECKBOX -> JCheckBox("", property.value.toBoolean())
         else -> JTextField(property.value)
       }
-      field.document.addDocumentListener(object : DocumentListener() {
-        override fun change(e: DocumentEvent) {
-          this@PropertyDialog.update()
-        }
-      })
-      field.addFocusListener(object : FocusListener() {
-        override fun focusGained(e: FocusEvent) {
-          fieldFocused = field
-          this@PropertyDialog.update()
-        }
-      })
+
+      if (field is JTextField) {
+        field.document.addDocumentListener(object : DocumentListener() {
+          override fun change(e: DocumentEvent) {
+            this@PropertyDialog.update()
+          }
+        })
+        field.addFocusListener(object : FocusListener() {
+          override fun focusGained(e: FocusEvent) {
+            fieldFocused = field
+            this@PropertyDialog.update()
+          }
+        })
+      }
+
       dialog.add(field, "width 300::, wrap")
 
       val validationMessage = JLabel()
       dialog.add(validationMessage, "skip, wrap")
 
-      PropertyDialogField(property, field, validationMessage)
+      PropertyDialogField(property, field, validationMessage, dialog)
     }
 
   private var closeButton = JButton().apply {
@@ -128,9 +134,7 @@ class PropertyDialog(private val config: Config) {
       UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
       val dialog = PropertyDialog(config)
       UIManager.setLookAndFeel(laf)
-
       return dialog
     }
   }
 }
-

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -54,7 +54,7 @@ class PropertyDialogField(private val property: Property, private val propField:
   }
 
   companion object {
-    val ERROR_TEXT_COLOR: Color? = Color(255, 80, 80)
-    val ERROR_FIELD_COLOR: Color? = Color(255, 221, 153)
+    val ERROR_TEXT_COLOR = Color(255, 80, 80)
+    val ERROR_FIELD_COLOR = Color(255, 221, 153)
   }
 }

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -3,10 +3,9 @@ package com.neva.gradle.fork.gui
 import com.neva.gradle.fork.config.properties.Property
 import com.neva.gradle.fork.config.properties.Validator
 import java.awt.Color
-import javax.swing.JLabel
-import javax.swing.JTextField
+import javax.swing.*
 
-class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel) {
+class PropertyDialogField(private val property: Property, private val propField: JComponent, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
 
   init {
     setPropertyValue()
@@ -26,11 +25,15 @@ class PropertyDialogField(private val property: Property, private val propField:
     } else {
       displayValidState()
     }
+    dialog.pack()
     return result.hasErrors()
   }
 
   private fun setPropertyValue() {
-    property.value = propField.text
+    when (propField) {
+      is JCheckBox -> property.value = propField.isSelected.toString()
+      is JTextField -> property.value = propField.text
+    }
   }
 
   private fun displayValidState() {

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -1,6 +1,6 @@
 package com.neva.gradle.fork.gui
 
-import com.neva.gradle.fork.config.Property
+import com.neva.gradle.fork.config.properties.Property
 import com.neva.gradle.fork.config.properties.ValidatorErrors
 import java.awt.Color
 import javax.swing.JDialog

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -1,0 +1,51 @@
+package com.neva.gradle.fork.gui
+
+import com.neva.gradle.fork.config.Property
+import com.neva.gradle.fork.config.properties.ValidatorErrors
+import java.awt.Color
+import javax.swing.JDialog
+import javax.swing.JLabel
+import javax.swing.JTextField
+
+data class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
+
+  val name: String
+    get() = property.name
+
+  val textValue: String
+    get() = propField.text
+
+  fun validateAndDisplayErrors(): Boolean {
+    val result = property.validate(textValue)
+    if (result.hasErrors()) {
+      displayErrorState(result)
+    } else {
+      displayValidState()
+    }
+    return result.hasErrors()
+  }
+
+  private fun displayValidState() {
+    validationMessageLabel.apply {
+      foreground = null
+      text = null
+    }
+    propField.background = null
+    dialog.pack()
+  }
+
+  private fun displayErrorState(result: ValidatorErrors) {
+    val errorMessage = "<html>${result.errors.joinToString(separator = "<br/>")}</html>"
+    validationMessageLabel.apply {
+      foreground = ERROR_TEXT_COLOR
+      text = errorMessage
+    }
+    propField.background = ERROR_FIELD_COLOR
+    dialog.pack()
+  }
+
+  companion object {
+    val ERROR_TEXT_COLOR: Color? = Color(255, 80, 80)
+    val ERROR_FIELD_COLOR: Color? = Color(255, 221, 153)
+  }
+}

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -3,20 +3,24 @@ package com.neva.gradle.fork.gui
 import com.neva.gradle.fork.config.properties.Property
 import com.neva.gradle.fork.config.properties.Validator
 import java.awt.Color
-import javax.swing.JDialog
 import javax.swing.JLabel
 import javax.swing.JTextField
 
-class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
+class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel) {
+
+  init {
+    setPropertyValue()
+  }
 
   val name: String
     get() = property.name
 
-  val textValue: String
-    get() = propField.text
+  val value: String
+    get() = property.value
 
   fun validateAndDisplayErrors(): Boolean {
-    val result = property.validate(textValue)
+    setPropertyValue()
+    val result = property.validate()
     if (result.hasErrors()) {
       displayErrorState(result)
     } else {
@@ -25,13 +29,16 @@ class PropertyDialogField(private val property: Property, private val propField:
     return result.hasErrors()
   }
 
+  private fun setPropertyValue() {
+    property.value = propField.text
+  }
+
   private fun displayValidState() {
     validationMessageLabel.apply {
       foreground = null
       text = null
     }
     propField.background = null
-    dialog.pack()
   }
 
   private fun displayErrorState(result: Validator) {
@@ -41,7 +48,6 @@ class PropertyDialogField(private val property: Property, private val propField:
       text = errorMessage
     }
     propField.background = ERROR_FIELD_COLOR
-    dialog.pack()
   }
 
   companion object {

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -1,7 +1,7 @@
 package com.neva.gradle.fork.gui
 
 import com.neva.gradle.fork.config.properties.Property
-import com.neva.gradle.fork.config.properties.ValidatorErrors
+import com.neva.gradle.fork.config.properties.Validator
 import java.awt.Color
 import javax.swing.JDialog
 import javax.swing.JLabel
@@ -34,7 +34,7 @@ class PropertyDialogField(private val property: Property, private val propField:
     dialog.pack()
   }
 
-  private fun displayErrorState(result: ValidatorErrors) {
+  private fun displayErrorState(result: Validator) {
     val errorMessage = "<html>${result.errors.joinToString(separator = "<br/>")}</html>"
     validationMessageLabel.apply {
       foreground = ERROR_TEXT_COLOR

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -7,7 +7,7 @@ import javax.swing.JDialog
 import javax.swing.JLabel
 import javax.swing.JTextField
 
-data class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
+class PropertyDialogField(private val property: Property, private val propField: JTextField, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
 
   val name: String
     get() = property.name

--- a/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/gui/PropertyDialogField.kt
@@ -5,10 +5,15 @@ import com.neva.gradle.fork.config.properties.Validator
 import java.awt.Color
 import javax.swing.*
 
-class PropertyDialogField(private val property: Property, private val propField: JComponent, private val validationMessageLabel: JLabel, private val dialog: JDialog) {
+class PropertyDialogField(
+  private val property: Property,
+  private val propField: JComponent,
+  private val validationMessageLabel: JLabel,
+  private val dialog: JDialog
+) {
 
   init {
-    setPropertyValue()
+    assignPropertyValue()
   }
 
   val name: String
@@ -18,7 +23,7 @@ class PropertyDialogField(private val property: Property, private val propField:
     get() = property.value
 
   fun validateAndDisplayErrors(): Boolean {
-    setPropertyValue()
+    assignPropertyValue()
     val result = property.validate()
     if (result.hasErrors()) {
       displayErrorState(result)
@@ -29,7 +34,7 @@ class PropertyDialogField(private val property: Property, private val propField:
     return result.hasErrors()
   }
 
-  private fun setPropertyValue() {
+  private fun assignPropertyValue() {
     when (propField) {
       is JCheckBox -> property.value = propField.isSelected.toString()
       is JTextField -> property.value = propField.text

--- a/src/main/kotlin/com/neva/gradle/fork/tasks/Props.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/tasks/Props.kt
@@ -1,5 +1,6 @@
 package com.neva.gradle.fork.tasks
 
+import com.neva.gradle.fork.config.Config
 import org.gradle.api.tasks.TaskAction
 
 open class Props : DefaultTask() {
@@ -7,22 +8,19 @@ open class Props : DefaultTask() {
   init {
     description = "Generates user specific 'gradle.properties' file basing on template and prompted values."
 
-    ext.inPlaceConfig(CONFIG_NAME) { copyTemplateFile(TEMPLATE_FILE) }
+    ext.inPlaceConfig(Config.NAME_PROPERTIES) { copyTemplateFile(TEMPLATE_FILE) }
   }
 
   @TaskAction
   fun properties() {
-    ext.config(CONFIG_NAME).evaluate()
+    ext.config(Config.NAME_PROPERTIES).evaluate()
   }
 
   companion object {
 
     const val NAME = "props"
 
-    const val CONFIG_NAME = "properties"
-
     const val TEMPLATE_FILE = "gradle.properties"
-
   }
 
 }

--- a/src/main/kotlin/com/neva/gradle/fork/template/TemplateEngine.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/template/TemplateEngine.kt
@@ -33,27 +33,18 @@ class TemplateEngine(val project: Project) {
     return renderer.toString()
   }
 
-  fun parse(template: String): Map<String, String?> {
+  fun parse(template: String): List<String> {
     val m = PROP_PATTERN.matcher(template)
 
-    val result = mutableMapOf<String, String?>()
+    val result = mutableListOf<String>()
     while (m.find()) {
       val prop = m.group(1)
 
-      if (prop.contains(PROP_DELIMITER)) {
+      result += if (prop.contains(PROP_DELIMITER)) {
         val parts = prop.split(PROP_DELIMITER).map { it.trim() }
-        val defaultName = parts[0]
-
-        val defaultExpr = parts.find { DEFAULT_REGEX.matches(it) }
-        val defaultValue = if (defaultExpr != null) {
-          render("$VAR_PREFIX$defaultName | $defaultExpr$VAR_SUFFIX", mapOf(defaultName to null))
-        } else {
-          null
-        }
-
-        result[defaultName] = defaultValue
+        parts[0]
       } else {
-        result[prop] = null
+        prop
       }
     }
 
@@ -62,15 +53,13 @@ class TemplateEngine(val project: Project) {
 
   companion object {
 
-    private val PROP_PATTERN = Pattern.compile("\\{\\{(.+?)\\}\\}")
+    private val PROP_PATTERN = Pattern.compile("\\{\\{(.+?)}}")
 
-    private val PROP_DELIMITER = "|"
+    private const val PROP_DELIMITER = "|"
 
-    private val DEFAULT_REGEX = Regex("default\\(([^\\(\\)]+)\\)")
+    private const val VAR_PREFIX = "{{"
 
-    private val VAR_PREFIX = "{{"
-
-    private val VAR_SUFFIX = "}}"
+    private const val VAR_SUFFIX = "}}"
 
     private val ENGINE = PebbleEngine.Builder()
       .extension(TemplateExtension())


### PR DESCRIPTION
- user is able to specify
  - default value
  - if field is required
  - validator
- validation messages displayed in the props dialog

I propose the following DSL:
```
fork {
    config {
        cloneFiles()
        moveFiles(mapOf(
                "/com/company/aem/example" to "/{{projectGroup|substitute(\".\", \"/\")}}/{{projectName}}",
                "/Example" to "/{{projectLabel}}",
                "/example" to "/{{projectName}}"
        ))
        replaceContents(mapOf(
                "com.company.aem.example" to "{{projectGroup}}.{{projectName}}",
                "com.company.aem" to "{{projectGroup}}",
                "Example" to "{{projectLabel}}",
                "example" to "{{projectName}}"
        ))
    }
    defineProperties(mapOf(
            "aemSmbDomain" to {
                required()
                defaultValue = "Damian is cool"
                validator = {
                }
            },
            "aemInstanceLocalJarUrl" to {
                required()
                validator = {
                    if (!it.contains("@")) error("Oh, this is not an email!")
                }
            }
    ))
}
```
