### PR TITLE
Props extension property access + alias

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,10 @@ tasks {
     }
 
     named("afterReleaseBuild") {
-        dependsOn("bintrayUpload", "publishPlugins", "githubRelease")
+        dependsOn("bintrayUpload", "publishPlugins")
+    }
+    named("release") {
+        finalizedBy("githubRelease")
     }
     named("updateVersion") {
         enabled = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=4.0.0
+version=4.0.1
 kotlin.version=1.3.50
 dokka.version=0.9.18
 detekt.version=1.0.1

--- a/src/main/kotlin/com/neva/gradle/fork/PropsExtension.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/PropsExtension.kt
@@ -7,7 +7,7 @@ open class PropsExtension(private val project: Project) {
 
   internal val encryptor = Encryption.of(project)
 
-  fun get(name: String): String? {
+  fun named(name: String): String? {
     val value = project.findProperty(name)?.toString()
     if (value.isNullOrBlank()) {
       return value
@@ -16,8 +16,12 @@ open class PropsExtension(private val project: Project) {
     return encryptor.decrypt(value)
   }
 
+  operator fun get(name: String) = named(name)
+
   companion object {
 
     const val NAME = "props"
+
+    const val ALIAS = "forkProps"
   }
 }

--- a/src/main/kotlin/com/neva/gradle/fork/PropsPlugin.kt
+++ b/src/main/kotlin/com/neva/gradle/fork/PropsPlugin.kt
@@ -14,7 +14,10 @@ open class PropsPlugin : Plugin<Project> {
 
   override fun apply(project: Project) {
     with(project) {
-      extensions.create(PropsExtension.NAME, PropsExtension::class.java, project)
+      PropsExtension(project).apply {
+        extensions.add(PropsExtension.NAME, this)
+        extensions.add(PropsExtension.ALIAS, this)
+      }
     }
   }
 }


### PR DESCRIPTION
`props` extension name looks quite generic and could be easily shadowed by some local variable

it would be nice to have alias `forkProps` pointing to `props` extension
also array access would reduce / simplify syntax